### PR TITLE
lost connection + revalidator polling causes uncatchable crash

### DIFF
--- a/app/HeirarchyForFun.tsx
+++ b/app/HeirarchyForFun.tsx
@@ -1,0 +1,17 @@
+import { Poller } from "./Poller";
+
+export const HeirarchyForFun = () => {
+  return (
+    <div>
+      <span>hola</span>
+      <Poller frequencyMs={1000} />
+    </div>
+  );
+};
+
+export const ErrorBoundary = ({ error }: { error: Error }) => (
+  <div>
+    <h1>Oops, something went wrong in HeirarchyForFun</h1>
+    <pre>{error.message}</pre>
+  </div>
+);

--- a/app/Poller.tsx
+++ b/app/Poller.tsx
@@ -1,0 +1,34 @@
+import { useRevalidator } from "@remix-run/react";
+import { useEffect } from "react";
+
+interface Props {
+  frequencyMs: number;
+}
+
+export const Poller = ({ frequencyMs }: Props) => {
+  usePolling(frequencyMs);
+
+  return null;
+};
+
+const usePolling = (frequencyMs: number) => {
+  const revalidator = useRevalidator();
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      if (revalidator.state === "idle") {
+        console.log("Revalidating page...");
+        revalidator.revalidate();
+      }
+    }, frequencyMs);
+
+    return () => clearInterval(interval);
+  }, [revalidator, frequencyMs]);
+};
+
+export const ErrorBoundary = ({ error }: { error: Error }) => (
+  <div>
+    <h1>Oops, something went wrong in Poller</h1>
+    <pre>{error.message}</pre>
+  </div>
+);

--- a/app/Poller.tsx
+++ b/app/Poller.tsx
@@ -1,4 +1,8 @@
-import { useRevalidator } from "@remix-run/react";
+import {
+  isRouteErrorResponse,
+  useRevalidator,
+  useRouteError,
+} from "@remix-run/react";
 import { useEffect } from "react";
 
 interface Props {
@@ -26,9 +30,20 @@ const usePolling = (frequencyMs: number) => {
   }, [revalidator, frequencyMs]);
 };
 
-export const ErrorBoundary = ({ error }: { error: Error }) => (
-  <div>
-    <h1>Oops, something went wrong in Poller</h1>
-    <pre>{error.message}</pre>
-  </div>
-);
+export function ErrorBoundary() {
+  const error = useRouteError();
+
+  if (error instanceof Error) {
+    return <div>Poller: An unexpected error occurred: {error.message}</div>;
+  }
+
+  if (!isRouteErrorResponse(error)) {
+    return <h1>Poller: Unknown Error</h1>;
+  }
+
+  if (error.status === 404) {
+    return <div>Poller: Note not found</div>;
+  }
+
+  return <div>Poller: An unexpected error occurred: {error.statusText}</div>;
+}

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,11 +8,12 @@ import {
   Outlet,
   Scripts,
   ScrollRestoration,
+  isRouteErrorResponse,
+  useRouteError,
 } from "@remix-run/react";
 
 import { getUser } from "~/session.server";
 import stylesheet from "~/tailwind.css";
-import { HeirarchyForFun } from "./HeirarchyForFun";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
@@ -37,15 +38,25 @@ export default function App() {
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
-        <HeirarchyForFun />
       </body>
     </html>
   );
 }
 
-export const ErrorBoundary = ({ error }: { error: Error }) => (
-  <div>
-    <h1>Oops, something went wrong in Root</h1>
-    <pre>{error.message}</pre>
-  </div>
-);
+// export function ErrorBoundary() {
+//   const error = useRouteError();
+
+//   if (error instanceof Error) {
+//     return <div>root: An unexpected error occurred: {error.message}</div>;
+//   }
+
+//   if (!isRouteErrorResponse(error)) {
+//     return <h1>root: Unknown Error</h1>;
+//   }
+
+//   if (error.status === 404) {
+//     return <div>root: Note not found</div>;
+//   }
+
+//   return <div>root: An unexpected error occurred: {error.statusText}</div>;
+// }

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -12,6 +12,7 @@ import {
 
 import { getUser } from "~/session.server";
 import stylesheet from "~/tailwind.css";
+import { HeirarchyForFun } from "./HeirarchyForFun";
 
 export const links: LinksFunction = () => [
   { rel: "stylesheet", href: stylesheet },
@@ -36,7 +37,15 @@ export default function App() {
         <ScrollRestoration />
         <Scripts />
         <LiveReload />
+        <HeirarchyForFun />
       </body>
     </html>
   );
 }
+
+export const ErrorBoundary = ({ error }: { error: Error }) => (
+  <div>
+    <h1>Oops, something went wrong in Root</h1>
+    <pre>{error.message}</pre>
+  </div>
+);

--- a/app/routes/notes.$noteId.tsx
+++ b/app/routes/notes.$noteId.tsx
@@ -7,6 +7,7 @@ import {
   useRouteError,
 } from "@remix-run/react";
 import invariant from "tiny-invariant";
+import { HeirarchyForFun } from "~/HeirarchyForFun";
 
 import { deleteNote, getNote } from "~/models/note.server";
 import { requireUserId } from "~/session.server";
@@ -39,6 +40,7 @@ export default function NoteDetailsPage() {
       <h3 className="text-2xl font-bold">{data.note.title}</h3>
       <p className="py-6">{data.note.body}</p>
       <hr className="my-4" />
+      <HeirarchyForFun />
       <Form method="post">
         <button
           type="submit"
@@ -55,16 +57,16 @@ export function ErrorBoundary() {
   const error = useRouteError();
 
   if (error instanceof Error) {
-    return <div>An unexpected error occurred: {error.message}</div>;
+    return <div>$notesId: An unexpected error occurred: {error.message}</div>;
   }
 
   if (!isRouteErrorResponse(error)) {
-    return <h1>Unknown Error</h1>;
+    return <h1>$notesId: Unknown Error</h1>;
   }
 
   if (error.status === 404) {
-    return <div>Note not found</div>;
+    return <div>$notesId: Note not found</div>;
   }
 
-  return <div>An unexpected error occurred: {error.statusText}</div>;
+  return <div>$notesId: An unexpected error occurred: {error.statusText}</div>;
 }


### PR DESCRIPTION
In this PR there is a component using revalidator to poll for update.  If in devtools you turn off the network, this results in a crash on the next poll.  Nested and root boundaries do not catch this error.